### PR TITLE
GitHub Actions ガイドラインに準拠

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,16 @@ on:
   pull_request_review:
     types: [submitted]
 
+# トップレベルの permissions はワークフロー内の全ジョブのデフォルト権限。
+# ジョブレベルで permissions を明示した場合はマージされず「完全に上書き」されるため、
+# claude ジョブには job レベルの権限がそのまま適用される。
+# ここでは将来ジョブが追加された場合に備えたデフォルトとして最小権限を設定する。
+permissions:
+  contents: read
+
+# concurrency は設定しない:
+# コメント・Issue ごとに独立した依頼として並行実行されるべきであり、
+# 後続のトリガーで実行中の処理をキャンセルすると対応中の依頼が中断されてしまうため
 jobs:
   claude:
     if: |
@@ -18,6 +28,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
@@ -25,23 +36,23 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: pnpm のセットアップ
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Node.js のセットアップ
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "./.node-version"
           cache: "pnpm"
 
-      - name: Run Claude Code
+      - name: Claude Code の実行
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           settings: .claude/settings.json
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,27 +19,49 @@ jobs:
     runs-on: macos-15
     steps:
       - name: チェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # e2e-test はマージの必須チェックのため、paths-ignore (ワークフロー自体が起動せず
+      # チェックが pass にならない) ではなく paths-filter によるステップレベル制御を行う。
+      # 対象: e2e がビルド・テストする web、web が依存する api、テスト本体の e2e、
+      #       依存バージョンや実行環境に影響する root の設定ファイルとこのワークフロー自身
+      - name: 変更ファイルの検出
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          predicate-quantifier: every # フィルターの条件を AND 条件にするために必要。default は some で OR 条件
+          filters: |
+            e2e:
+              - "{packages/web/**,packages/api/**,packages/e2e/**,package.json,pnpm-workspace.yaml,pnpm-lock.yaml,.node-version,.github/workflows/e2e-test.yml}"
+              - "!**/*.md"
 
       - name: pnpm のセットアップ
-        uses: pnpm/action-setup@v4
-      - name: Node.js セットアップ
-        uses: actions/setup-node@v4
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - name: Node.js のセットアップ
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "./.node-version"
           cache: "pnpm"
       - name: パッケージインストール
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
         run: pnpm install
       - name: Playwright ブラウザインストール
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
         run: pnpm --filter e2e exec playwright install --with-deps
 
       - name: Web ビルド
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
         run: MOCK_BLOG_CLIENT=true pnpm --filter web run build
+
       - name: e2e テスト
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
         run: pnpm --filter e2e run test
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+      - name: Playwright レポートのアップロード
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.filter.outputs.e2e == 'true' }}
         with:
           name: playwright-report
           path: packages/e2e/playwright-report/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -20,17 +23,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: チェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # lint はマージの必須チェックのため、paths-ignore (ワークフロー自体が起動せず
+      # チェックが pass にならない) ではなく paths-filter によるステップレベル制御を行う。
+      # 対象: 全パッケージ (--filter "*" で全パッケージを lint するため)、
+      #       lint 設定・依存バージョン・実行環境に影響する root の設定ファイルとこのワークフロー自身
+      - name: 変更ファイルの検出
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          predicate-quantifier: every # フィルターの条件を AND 条件にするために必要。default は some で OR 条件
+          filters: |
+            lint:
+              - "{packages/**,package.json,pnpm-workspace.yaml,pnpm-lock.yaml,.node-version,biome.jsonc,.github/workflows/lint.yml}"
+              - "!**/*.md"
+
       - name: pnpm のセットアップ
-        uses: pnpm/action-setup@v4
+        if: ${{ steps.filter.outputs.lint == 'true' }}
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - name: Node.js のセットアップ
-        uses: actions/setup-node@v4
+        if: ${{ steps.filter.outputs.lint == 'true' }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "./.node-version"
           cache: "pnpm"
       - name: パッケージインストール
+        if: ${{ steps.filter.outputs.lint == 'true' }}
         run: pnpm install
       - name: Lint & フォーマットチェック
+        if: ${{ steps.filter.outputs.lint == 'true' }}
         run: pnpm --filter "*" lint-format:check
       - name: type チェック
+        if: ${{ steps.filter.outputs.lint == 'true' }}
         run: pnpm --filter "*" type:check

--- a/.github/workflows/renovate-config-check.yml
+++ b/.github/workflows/renovate-config-check.yml
@@ -1,9 +1,13 @@
 name: Renovate 設定検証
 
+# マージの必須チェックにするため、paths でトリガー自体を絞る (起動しないと
+# チェックが pass にならない) のではなく、全 PR で起動して paths-filter による
+# ステップレベル制御を行う
 on:
   pull_request:
-    paths:
-      - ".github/renovate.json5"
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,17 +24,37 @@ jobs:
 
     steps:
       - name: チェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # 対象: renovate 設定本体、検証に使う renovate のバージョンに影響する root の
+      #       設定ファイル、このワークフロー自身
+      - name: 変更ファイルの検出
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          filters: |
+            renovate-config:
+              - ".github/renovate.json5"
+              - ".github/workflows/renovate-config-check.yml"
+              - "package.json"
+              - "pnpm-workspace.yaml"
+              - "pnpm-lock.yaml"
+              - ".node-version"
+
       - name: pnpm のセットアップ
-        uses: pnpm/action-setup@v4
+        if: ${{ steps.filter.outputs.renovate-config == 'true' }}
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - name: Node.js のセットアップ
-        uses: actions/setup-node@v4
+        if: ${{ steps.filter.outputs.renovate-config == 'true' }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "./.node-version"
           cache: pnpm
 
       - name: パッケージインストール
+        if: ${{ steps.filter.outputs.renovate-config == 'true' }}
         run: pnpm install
 
       - name: renovate の設定ファイルの検証
+        if: ${{ steps.filter.outputs.renovate-config == 'true' }}
         run: pnpm exec renovate-config-validator .github/renovate.json5


### PR DESCRIPTION
## 概要

[GitHub Actions ガイドライン](https://github.com/harusame-dev/development-policy/blob/main/GithubActions%E3%82%AC%E3%82%A4%E3%83%89%E3%83%A9%E3%82%A4%E3%83%B3.md)への準拠調査を行い、違反箇所を修正しました。

## 変更内容

### 1. permissions 設定（ガイドライン項目 1）

- e2e-test / lint / renovate-config-check にトップレベル `permissions: contents: read` を追加
- claude.yml はトップレベルにデフォルトの最小権限を追加し、ジョブレベルの write 系権限は維持（ジョブレベルはトップレベルとマージされず完全に上書きされる関係をコメントで明記）

### 2. ステップ名の日本語化（項目 2）

- claude.yml の全ステップを日本語化
- e2e-test.yml の名前なしステップ（upload-artifact）に「Playwright レポートのアップロード」を追加

### 3. claude.yml の concurrency / timeout（項目 5・6）

- concurrency を設定しない理由（コメント・Issue ごとに独立した依頼のため、後続トリガーでキャンセルすべきでない）をコメントで明記
- `timeout-minutes: 10` を追加（未設定だとデフォルト 360 分まで課金され続けるため）

### 4. paths-filter による不要実行のスキップ（項目 7）

e2e-test / lint はマージの必須チェックのため、`paths-ignore` ではなく `dorny/paths-filter` によるステップレベル制御を導入。パッケージの依存関係（web → api、e2e は web をビルドしてテスト）を元にフィルタを設計。

| ワークフロー | 対象パス |
|---|---|
| e2e-test | packages/web・api・e2e + root 設定ファイル + ワークフロー自身（md 除外） |
| lint | packages 全体 + root 設定ファイル + biome.jsonc + ワークフロー自身（md 除外） |
| renovate-config-check | renovate.json5 + root 設定ファイル + ワークフロー自身 |

renovate-config-check は必須チェック化に備え、`paths:` トリガーを外して全 PR で起動する方式に変更。

### 5. SHA ピン留め（項目 8）

pinact で全 Action をコミット SHA + バージョンコメント形式にピン留め。

- actions/checkout v4.3.1
- pnpm/action-setup v4.3.0
- actions/setup-node v4.4.0
- actions/upload-artifact v4.6.2
- anthropics/claude-code-action v1.0.146
- dorny/paths-filter v3.0.3（新規導入）

## マージ後の作業

- [ ] main のルールセットの required_status_checks にジョブ名 `validate-config` を追加（renovate-config-check の必須チェック化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
