### PR TITLE
fix: allowBuilds をパッケージ列挙形式へ修正し pnpm を 11.5.0 へ更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "",
 	"main": "index.js",
-	"packageManager": "pnpm@10.26.1",
+	"packageManager": "pnpm@11.5.0",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"lint-format:write": "pnpm --filter '*' run lint-format:write"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,9 +18,20 @@ minimumReleaseAgeExclude:
 # pnpm add 時に ^ や ~ を付けず exact version で package.json に記録する
 savePrefix: ""
 
-# 依存パッケージのビルドスクリプト (preinstall / postinstall 等) の実行を明示的に禁止する
-# (サプライチェーン攻撃の主要経路の遮断。必要になったら onlyBuiltDependencies で個別許可する)
-allowBuilds: false
+# 依存パッケージのビルドスクリプト (preinstall / postinstall 等) はデフォルト実行禁止。
+# ビルドスクリプトを持つパッケージはレビューのうえ false (禁止) / true (許可) を明示的に列挙する
+# (サプライチェーン攻撃の主要経路の遮断。pnpm 11 では未列挙のままだとインストールがエラーになる)
+allowBuilds:
+  '@biomejs/biome': false
+  better-sqlite3: false
+  core-js-pure: false
+  dtrace-provider: false
+  esbuild: false
+  msw: false
+  protobufjs: false
+  re2: false
+  sharp: false
+  workerd: false
 
 # すべての依存のバージョンを catalog で一元管理する
 # (pnpm add 時はカタログへ自動登録され、カタログ外バージョンの追加はエラーになる)


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` の `allowBuilds: false`（boolean）を pnpm の仕様に沿ったパッケージ列挙形式へ修正し、あわせて pnpm を 11 系の最新安定版 11.5.0 へ更新します。

## 背景

`allowBuilds`（pnpm 10.26 で追加）はパッケージ名をキーとするマップ専用の設定で、boolean の `false` は指定できません。boolean 指定は未列挙と同じ「未レビュー」扱いとなり、pnpm 10.26.1 では警告止まりですが、`strictDepBuilds` がデフォルト有効な pnpm 11 ではフレッシュインストールが `ERR_PNPM_IGNORED_BUILDS` でエラー終了します（jukubox の CI で実際に発生: harusame-dev/jukubox#163）。

ポリシー文書側の修正: harusame-dev/development-policy#2

## 変更内容

### 1. allowBuilds の列挙形式への修正
- フレッシュインストールで実測した「ビルドスクリプトを持つ全 10 パッケージ」（@biomejs/biome / better-sqlite3 / core-js-pure / dtrace-provider / esbuild / msw / protobufjs / re2 / sharp / workerd）を、レビュー済み・実行禁止（`false`）として明示列挙
- いずれも現状ビルドスクリプト未実行のまま動作しているため、挙動の変更はなし

### 2. pnpm 10.26.1 → 11.5.0
- 公開から 14 日以上経過しているバージョンの中で最新の 11.5.0（2026-05-29 公開）を採用（11.5.1〜11.6.0 は 14 日未経過のため見送り）
- CI の pnpm/action-setup は version 省略で `packageManager` を参照しているため、ワークフローの変更は不要

## 検証

- [x] pnpm 11.5.0 で node_modules 削除後の `pnpm install --frozen-lockfile` が成功（strictDepBuilds 有効下で「Ignored build scripts」エラー・警告なし）
- [x] lockfile への変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)